### PR TITLE
feat/mcp-to-toolbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,7 +1043,6 @@ dependencies = [
 name = "fabricatio-tool"
 version = "0.0.0"
 dependencies = [
- "futures",
  "mcp-manager",
  "pyo3",
  "pyo3-async-runtimes",
@@ -1052,6 +1051,7 @@ dependencies = [
  "rustpython-ast",
  "rustpython-parser",
  "serde_json",
+ "signify",
 ]
 
 [[package]]
@@ -3583,6 +3583,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signify"
+version = "0.1.0"
+dependencies = [
+ "heck",
+ "indoc",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -111,22 +111,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1047,7 +1047,6 @@ dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
  "pythonize",
- "rmcp",
  "rustpython-ast",
  "rustpython-parser",
  "serde_json",
@@ -2266,26 +2265,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25be21376a772d15f97ae789845340a9651d3c4246ff5ebb6a2b35f9c37bd31"
 
 [[package]]
-name = "oauth2"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
-dependencies = [
- "base64",
- "chrono",
- "getrandom 0.2.16",
- "http",
- "rand 0.8.5",
- "reqwest",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2891,7 +2870,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3173,15 +3152,14 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0d0d5493be0d181a62db489eab7838669b81885972ca00ceca893cf6ac2883"
+checksum = "9a04b2d9da174d72bc0511410242eb3e8f47a02d9e23868e4b076c7c70208eb4"
 dependencies = [
  "base64",
  "chrono",
  "futures",
  "http",
- "oauth2",
  "paste",
  "pin-project-lite",
  "process-wrap",
@@ -3196,14 +3174,13 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
- "url",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aebc912b8fa7d54999adc4e45601d1d95fe458f97eb0a1277eddcd6382cf4b1"
+checksum = "651b4292f292d4a4ba191e64f0ce553aef5455b8ddf831dc6a8cd328dd68d721"
 dependencies = [
  "darling 0.21.1",
  "proc-macro2",
@@ -3501,16 +3478,6 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_path_to_error"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
-dependencies = [
- "itoa",
  "serde",
 ]
 
@@ -4578,7 +4545,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]
@@ -5274,9 +5240,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbb9122ea75b11bf96e7492afb723e8a7fbe12c67417aa95e7e3d18144d37cd"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,6 +1047,7 @@ dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
  "pythonize",
+ "rmcp",
  "rustpython-ast",
  "rustpython-parser",
  "serde_json",
@@ -2870,7 +2871,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "packages/fabricatio-anki/src/deck_loader",
     "packages/fabricatio-tool",
     "packages/fabricatio-tool/crates/mcp-manager",
+    "packages/fabricatio-tool/crates/signify",
     "packages/fabricatio-locale",
     "packages/fabricatio-thinking",
     "packages/fabricatio-agent",

--- a/packages/fabricatio-core/pyproject.toml
+++ b/packages/fabricatio-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio-core"
-version = "0.3.24-dev0"
+version = "0.3.24-dev1"
 description = "A foundational Python library providing core components for building LLM-driven applications using an event-based agent structure."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/packages/fabricatio-core/pyproject.toml
+++ b/packages/fabricatio-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio-core"
-version = "0.3.23"
+version = "0.3.24-dev0"
 description = "A foundational Python library providing core components for building LLM-driven applications using an event-based agent structure."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/packages/fabricatio-core/pyproject.toml
+++ b/packages/fabricatio-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio-core"
-version = "0.3.24-dev1"
+version = "0.3.24"
 description = "A foundational Python library providing core components for building LLM-driven applications using an event-based agent structure."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/packages/fabricatio-core/python/fabricatio_core/fs/curd.py
+++ b/packages/fabricatio-core/python/fabricatio_core/fs/curd.py
@@ -6,10 +6,11 @@ from os import PathLike
 from pathlib import Path
 from typing import Union
 
-from fabricatio_core.decorators import depend_on_external_cmd
+from fabricatio_core.decorators import confirm_to_execute, depend_on_external_cmd
 from fabricatio_core.journal import logger
 
 
+@confirm_to_execute
 def dump_text(path: Union[str, Path], text: str) -> None:
     """Dump text to a file. you need to make sure the file's parent directory exists.
 
@@ -23,6 +24,7 @@ def dump_text(path: Union[str, Path], text: str) -> None:
     Path(path).write_text(text, encoding="utf-8", errors="ignore", newline="\n")
 
 
+@confirm_to_execute
 def copy_file(src: Union[str, Path], dst: Union[str, Path]) -> None:
     """Copy a file from source to destination.
 
@@ -42,6 +44,7 @@ def copy_file(src: Union[str, Path], dst: Union[str, Path]) -> None:
         raise
 
 
+@confirm_to_execute
 def move_file(src: Union[str, Path], dst: Union[str, Path]) -> None:
     """Move a file from source to destination.
 
@@ -61,6 +64,7 @@ def move_file(src: Union[str, Path], dst: Union[str, Path]) -> None:
         raise
 
 
+@confirm_to_execute
 def delete_file(file_path: Union[str, Path]) -> None:
     """Delete a file.
 
@@ -79,6 +83,7 @@ def delete_file(file_path: Union[str, Path]) -> None:
         raise
 
 
+@confirm_to_execute
 def create_directory(dir_path: Union[str, Path], parents: bool = True, exist_ok: bool = True) -> None:
     """Create a directory.
 
@@ -106,6 +111,7 @@ def tree(dir_path: Union[str, Path]) -> str:
     return subprocess.check_output(("erd", dir_path.as_posix()), encoding="utf-8")  # noqa: S603
 
 
+@confirm_to_execute
 def delete_directory(dir_path: Union[str, Path]) -> None:
     """Delete a directory and its contents.
 

--- a/packages/fabricatio-core/src/config.rs
+++ b/packages/fabricatio-core/src/config.rs
@@ -480,9 +480,8 @@ pub struct Config {
 
 #[pymethods]
 impl Config {
-
     /// Load configuration data for a given section name and instantiate a Python class
-    /// 
+    ///
     /// This method performs configuration loading with the following behavior:
     /// - Looks up configuration data by section name from extension configuration store
     /// - Converts the data to Python objects using serde serialization

--- a/packages/fabricatio-core/src/config.rs
+++ b/packages/fabricatio-core/src/config.rs
@@ -433,6 +433,7 @@ pub struct Config {
     /// - `liststr_template`: String list display template
     /// - `pathstr_template`: Path string acquisition template
     /// - `create_json_obj_template`: JSON object creation template
+    /// - ...
     #[pyo3(get)]
     pub templates: TemplateConfig,
 
@@ -474,18 +475,39 @@ pub struct Config {
     ///
     /// Additional configuration values as key-value pairs.
     /// Used for storing arbitrary extra configuration data.
-    pub extension: HashMap<String, Value>,
+    pub ext: HashMap<String, Value>,
 }
 
 #[pymethods]
 impl Config {
+
+    /// Load configuration data for a given section name and instantiate a Python class
+    /// 
+    /// This method performs configuration loading with the following behavior:
+    /// - Looks up configuration data by section name from extension configuration store
+    /// - Converts the data to Python objects using serde serialization
+    /// - Instantiates the provided Python class with the configuration data
+    ///
+    /// # Arguments
+    /// * `name` - Name of the configuration section to load
+    /// * `cls` - Python class to instantiate, must accept keyword arguments
+    ///
+    /// # Returns
+    /// `PyResult<Bound<'a, PyAny>>` containing either:
+    /// - Successfully initialized class instance with loaded config data
+    /// - Default-initialized class instance if section not found
+    ///
+    /// # Errors
+    /// Returns PyRuntimeError if:
+    /// - Data deserialization to Python types fails
+    /// - Class initialization fails with invalid arguments
     fn load<'a>(
         &self,
         python: Python<'a>,
         name: &str,
         cls: Bound<'a, PyAny>,
     ) -> PyResult<Bound<'a, PyAny>> {
-        if let Some(data) = self.extension.get(name) {
+        if let Some(data) = self.ext.get(name) {
             let any = pythonize(python, data)?;
             cls.call((), Some(&any.downcast_into_exact::<PyDict>()?))
         } else {

--- a/packages/fabricatio-core/src/logger.rs
+++ b/packages/fabricatio-core/src/logger.rs
@@ -53,8 +53,8 @@ where
         };
 
         write!(writer, "{}", colored_msg)?;
-
         ctx.format_fields(writer.by_ref(), event)?;
+        write!(writer, "\x1b[0m")?;
 
         writeln!(writer)
     }

--- a/packages/fabricatio-tool/Cargo.toml
+++ b/packages/fabricatio-tool/Cargo.toml
@@ -9,13 +9,6 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.25.0", features = ["extension-module"] }
 pyo3-async-runtimes = { version = "0.25.0", features = ["tokio-runtime"] }
 pythonize = "0.25.0"
-rmcp = { version = "0.3.2", features = [
-    "client",
-    "transport-child-process",
-    "transport-io",
-    "transport-sse-client",
-    "transport-streamable-http-client"
-] }
 rustpython-ast = { version = "0.4.0", features = ["visitor"] }
 rustpython-parser = { version = "0.4.0"  }
 serde_json = "1.0.142"

--- a/packages/fabricatio-tool/Cargo.toml
+++ b/packages/fabricatio-tool/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-futures = "0.3.31"
-
 pyo3 = { version = "0.25.0", features = ["extension-module"] }
 pyo3-async-runtimes = { version = "0.25.0", features = ["tokio-runtime"] }
 pythonize = "0.25.0"
@@ -22,3 +20,4 @@ rustpython-ast = { version = "0.4.0", features = ["visitor"] }
 rustpython-parser = { version = "0.4.0"  }
 serde_json = "1.0.142"
 mcp-manager = { path = "./crates/mcp-manager" }
+signify =  { path = "./crates/signify" }

--- a/packages/fabricatio-tool/Cargo.toml
+++ b/packages/fabricatio-tool/Cargo.toml
@@ -14,3 +14,4 @@ rustpython-parser = { version = "0.4.0"  }
 serde_json = "1.0.142"
 mcp-manager = { path = "./crates/mcp-manager" }
 signify =  { path = "./crates/signify" }
+rmcp = "0.4.0"

--- a/packages/fabricatio-tool/crates/mcp-manager/Cargo.toml
+++ b/packages/fabricatio-tool/crates/mcp-manager/Cargo.toml
@@ -5,14 +5,7 @@ edition = "2024"
 
 [dependencies]
 futures = "0.3.31"
-rmcp = { version = "0.3.2", features = [
-    "auth",
-    "client",
-    "transport-child-process",
-    "transport-io",
-    "transport-sse-client",
-    "transport-streamable-http-client"
-] }
+rmcp = { version = "0.4.0", features = ["client", "reqwest", "transport-child-process", "transport-io", "transport-sse-client", "transport-streamable-http-client"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
 tokio = { version = "1.47.1", features = ["process", "rt-multi-thread", "sync"] }

--- a/packages/fabricatio-tool/crates/mcp-manager/src/lib.rs
+++ b/packages/fabricatio-tool/crates/mcp-manager/src/lib.rs
@@ -1,12 +1,12 @@
 use futures::future::BoxFuture;
-use futures::{FutureExt, StreamExt, TryFutureExt, stream};
+use futures::{stream, FutureExt, StreamExt, TryFutureExt};
 use rmcp::model::{CallToolRequestParam, Tool};
 use rmcp::service::{DynService, RunningService};
-use rmcp::transport::ConfigureCommandExt;
 use rmcp::transport::child_process::TokioChildProcess;
 use rmcp::transport::sse_client::SseClientTransport;
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransport;
 use rmcp::transport::worker::WorkerTransport;
+use rmcp::transport::ConfigureCommandExt;
 use rmcp::{RoleClient, ServiceExt};
 use serde::{Deserialize, Serialize};
 use serde_json::value::Value;
@@ -320,6 +320,7 @@ impl MCPManager {
             .ok_or(McpError::ClientNotFound(client_id.to_owned()))?
             .await
     }
+
 }
 
 #[cfg(test)]

--- a/packages/fabricatio-tool/crates/mcp-manager/src/lib.rs
+++ b/packages/fabricatio-tool/crates/mcp-manager/src/lib.rs
@@ -1,12 +1,12 @@
 use futures::future::BoxFuture;
-use futures::{stream, FutureExt, StreamExt, TryFutureExt};
+use futures::{FutureExt, StreamExt, TryFutureExt, stream};
 use rmcp::model::{CallToolRequestParam, Tool};
 use rmcp::service::{DynService, RunningService};
+use rmcp::transport::ConfigureCommandExt;
 use rmcp::transport::child_process::TokioChildProcess;
 use rmcp::transport::sse_client::SseClientTransport;
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransport;
 use rmcp::transport::worker::WorkerTransport;
-use rmcp::transport::ConfigureCommandExt;
 use rmcp::{RoleClient, ServiceExt};
 use serde::{Deserialize, Serialize};
 use serde_json::value::Value;
@@ -320,7 +320,6 @@ impl MCPManager {
             .ok_or(McpError::ClientNotFound(client_id.to_owned()))?
             .await
     }
-
 }
 
 #[cfg(test)]

--- a/packages/fabricatio-tool/crates/signify/Cargo.toml
+++ b/packages/fabricatio-tool/crates/signify/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "signify"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+heck = "0.5.0"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.142"
+
+[dev-dependencies]
+indoc = "2.0.6"

--- a/packages/fabricatio-tool/crates/signify/src/lib.rs
+++ b/packages/fabricatio-tool/crates/signify/src/lib.rs
@@ -1,0 +1,467 @@
+//! Library for converting JSON Schema objects into Python function signatures and Google-style docstrings.
+//!
+//! This library parses a JSON Schema representing function parameters and generates the corresponding
+//! Python type hints for the function signature and the `Args:` section of a Google-style docstring.
+//! It strictly adheres to the convention that all non-required parameters are typed as `Optional[T] = None`
+//! in both the signature and the docstring.
+
+use heck::ToSnakeCase;
+// For sorted_by_key and other iterator utilities
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashSet;
+
+// --- Data Structures for JSON Schema Parsing ---
+
+/// Represents a parsed JSON Schema object relevant to function parameters.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct JsonSchema {
+    /// Map of parameter names to their schema definitions.
+    #[serde(default)]
+    properties: serde_json::Map<String, Value>,
+    /// List of parameter names that are required.
+    #[serde(default)]
+    required: Vec<String>,
+    // Other fields like 'type' or 'additionalProperties' could be added for stricter validation
+}
+
+/// Holds processed information about a single function parameter.
+#[derive(Debug, Clone)]
+struct ParameterInfo {
+    /// The parameter name converted to Python's snake_case convention.
+    name: String,
+    /// The base Python type (e.g., "str", "List[str]", "bool").
+    base_py_type: String,
+    /// The description of the parameter from the schema.
+    description: String,
+    /// Indicates if the parameter is required.
+    is_required: bool,
+    /// Optional list of allowed string values if the parameter is an enum.
+    allowed_values: Option<Vec<String>>,
+}
+
+// --- Type Mapping Logic ---
+
+/// Maps a JSON Schema type string and its definition to a Python type string.
+fn map_json_type_to_python(json_type: &str, prop_obj: &serde_json::Map<String, Value>) -> String {
+    match json_type {
+        "string" => "str".to_string(),
+        "number" => "float".to_string(),
+        "integer" => "int".to_string(),
+        "boolean" => "bool".to_string(),
+        "array" => {
+            let items_type_str = prop_obj
+                .get("items")
+                .and_then(|items| items.as_object())
+                .and_then(|items_obj| items_obj.get("type"))
+                .and_then(|t| t.as_str())
+                .map(map_item_type_to_python)
+                .unwrap_or_else(|| "Any".to_string());
+            format!("List[{}]", items_type_str)
+        }
+        "object" => "Dict[str, Any]".to_string(),
+        _ => json_type.to_string(), // Fallback for unknown or custom types
+    }
+}
+
+/// Maps a JSON Schema item type string (found within an `array` type's `items`) to a Python type string.
+fn map_item_type_to_python(json_item_type: &str) -> String {
+    match json_item_type {
+        "string" => "str".to_string(),
+        "number" => "float".to_string(),
+        "integer" => "int".to_string(),
+        "boolean" => "bool".to_string(),
+        "array" => "list".to_string(),  // Simplified for nested arrays
+        "object" => "dict".to_string(), // Simplified for nested objects
+        _ => "Any".to_string(),         // Fallback for complex or unspecified item types
+    }
+}
+
+// --- Core Conversion Logic ---
+
+/// Extracts ParameterInfo structs from the schema, ordered: required first (in "required" array order), then optional (in properties order).
+fn extract_parameter_infos(schema: &JsonSchema) -> Vec<ParameterInfo> {
+    let required_set: HashSet<&String> = schema.required.iter().collect();
+    let mut ordered = Vec::new();
+    // 1. Required
+    for req_name in &schema.required {
+        if let Some((original_name, prop_value)) = schema.properties.get_key_value(req_name)
+            && let Some(param_info) =
+                process_property(&original_name.to_snake_case(), prop_value, true)
+        {
+            ordered.push(param_info);
+        }
+    }
+    // 2. Optional
+    for (original_name, prop_value) in &schema.properties {
+        if !required_set.contains(original_name)
+            && let Some(param_info) =
+                process_property(&original_name.to_snake_case(), prop_value, false)
+        {
+            ordered.push(param_info);
+        }
+    }
+    ordered
+}
+
+fn format_signature_param(param_info: &ParameterInfo) -> String {
+    if param_info.is_required {
+        format!("{}: {}", param_info.name, param_info.base_py_type)
+    } else {
+        format!(
+            "{}: Optional[{}] = None",
+            param_info.name, param_info.base_py_type
+        )
+    }
+}
+
+fn format_docstring_arg(param_info: &ParameterInfo) -> String {
+    let docstring_type = if param_info.is_required {
+        param_info.base_py_type.clone()
+    } else {
+        format!("Optional[{}]", param_info.base_py_type)
+    };
+    let mut line = format!("    {}: {}", param_info.name, docstring_type);
+    if !param_info.description.is_empty() {
+        line.push_str(&format!(": {}", param_info.description.trim()));
+    }
+    if param_info.is_required {
+        line.push_str(" (required)");
+    }
+    if let Some(values) = &param_info.allowed_values {
+        line.push_str(&format!(" (allowed values: {})", values.join(", ")));
+    }
+    line
+}
+
+/// Generates a Python function signature string from a JSON Schema.
+///
+/// # Arguments
+/// * `schema_value`: A `serde_json::Value` representing the JSON Schema.
+///
+/// # Returns
+/// * `Some(String)`: The generated Python signature string (e.g., "(param1: Type1, param2: Optional[Type2] = None)").
+/// * `None`: If the input schema is invalid or not an object schema.
+pub fn schema_to_signature(schema_value: &Value) -> Option<String> {
+    let schema: JsonSchema = serde_json::from_value(schema_value.clone()).ok()?;
+    let infos = extract_parameter_infos(&schema);
+    let param_strings: Vec<String> = infos.iter().map(format_signature_param).collect();
+    Some(format!("({})", param_strings.join(", ")))
+}
+
+/// Generates the `Args:` section of a Google-style Python docstring from a JSON Schema.
+///
+/// # Arguments
+/// * `schema_value`: A `serde_json::Value` representing the JSON Schema.
+///
+/// # Returns
+/// * `Some(String)`: The generated docstring `Args:` section.
+/// * `None`: If the input schema is invalid, not an object schema, or has no properties.
+pub fn schema_to_docstring_args(schema_value: &Value) -> Option<String> {
+    let schema: JsonSchema = serde_json::from_value(schema_value.clone()).ok()?;
+    if schema.properties.is_empty() {
+        return None;
+    }
+    let infos = extract_parameter_infos(&schema);
+    let args_lines: Vec<String> = infos.iter().map(format_docstring_arg).collect();
+    if args_lines.is_empty() {
+        None
+    } else {
+        Some(format!("Args:\n{}", args_lines.join("\n")))
+    }
+}
+
+/// Processes a single property definition from the JSON Schema.
+///
+/// This function extracts the base type, description, and enum values.
+///
+/// # Arguments
+/// * `snake_name`: The parameter name already converted to snake_case.
+/// * `prop_value`: The `serde_json::Value` representing the property's schema.
+/// * `is_required`: A boolean indicating if this property is required.
+///
+/// # Returns
+/// * `Some(ParameterInfo)`: The processed information for the parameter.
+/// * `None`: If the property definition is invalid or missing a type.
+fn process_property(
+    snake_name: &str,
+    prop_value: &Value,
+    is_required: bool,
+) -> Option<ParameterInfo> {
+    let prop_obj = prop_value.as_object()?;
+    let json_type = prop_obj.get("type")?.as_str()?;
+
+    let base_py_type = map_json_type_to_python(json_type, prop_obj);
+
+    let description = prop_obj
+        .get("description")
+        .and_then(|d| d.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let allowed_values = if json_type == "string" {
+        prop_obj
+            .get("enum")
+            .and_then(|e| e.as_array())
+            .map(|enum_array| {
+                enum_array
+                    .iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+    } else {
+        None
+    };
+
+    Some(ParameterInfo {
+        name: snake_name.to_string(),
+        base_py_type,
+        description,
+        is_required,
+        allowed_values,
+    })
+}
+
+// --- Tests ---
+// (Tests remain functionally the same and should still pass)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+    use serde_json::json;
+
+    // Helper to create schema JSON for tests
+    fn schema_from_props_and_required(
+        properties: serde_json::Map<String, Value>,
+        required: Vec<&str>,
+    ) -> Value {
+        json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": properties,
+            "required": required,
+            "type": "object"
+        })
+    }
+
+    #[test]
+    fn test_empty_schema() {
+        let schema_value = schema_from_props_and_required(serde_json::Map::new(), vec![]);
+        let signature = schema_to_signature(&schema_value);
+        assert_eq!(signature, Some("()".to_string()));
+        let docstring = schema_to_docstring_args(&schema_value);
+        assert_eq!(docstring, None);
+    }
+
+    #[test]
+    fn test_width_height_schema() {
+        let mut properties = serde_json::Map::new();
+        properties.insert(
+            "height".to_string(),
+            json!({"description": "Height of the browser window", "type": "number"}),
+        );
+        properties.insert(
+            "width".to_string(),
+            json!({"description": "Width of the browser window", "type": "number"}),
+        );
+        let schema_value = schema_from_props_and_required(properties, vec!["width", "height"]);
+
+        let signature = schema_to_signature(&schema_value);
+        assert_eq!(signature, Some("(width: float, height: float)".to_string()));
+
+        let expected_docstring = indoc! {"
+            Args:
+                width: float: Width of the browser window (required)
+                height: float: Height of the browser window (required)
+        "}
+        .trim_end();
+        let docstring = schema_to_docstring_args(&schema_value);
+        assert_eq!(docstring, Some(expected_docstring.to_string()));
+    }
+
+    #[test]
+    fn test_accept_prompt_text_schema() {
+        let mut properties = serde_json::Map::new();
+        properties.insert(
+            "accept".to_string(),
+            json!({"description": "Whether to accept the dialog.", "type": "boolean"}),
+        );
+        properties.insert(
+            "promptText".to_string(),
+            json!({"description": "The text of the prompt in case of a prompt dialog.", "type": "string"}),
+        );
+        let schema_value = schema_from_props_and_required(properties, vec!["accept"]);
+
+        let signature = schema_to_signature(&schema_value);
+        assert_eq!(
+            signature,
+            Some("(accept: bool, prompt_text: Optional[str] = None)".to_string())
+        );
+
+        let expected_docstring = indoc! {"
+            Args:
+                accept: bool: Whether to accept the dialog. (required)
+                prompt_text: Optional[str]: The text of the prompt in case of a prompt dialog.
+        "}
+        .trim_end();
+        let docstring = schema_to_docstring_args(&schema_value);
+        assert_eq!(docstring, Some(expected_docstring.to_string()));
+    }
+
+    #[test]
+    fn test_click_schema_with_enum() {
+        let mut properties = serde_json::Map::new();
+        properties.insert(
+            "button".to_string(),
+            json!({
+                "description": "Button to click, defaults to left",
+                "enum": ["left", "right", "middle"],
+                "type": "string"
+            }),
+        );
+        properties.insert(
+            "doubleClick".to_string(),
+            json!({"description": "Whether to perform a double click instead of a single click", "type": "boolean"}),
+        );
+        properties.insert(
+            "element".to_string(),
+            json!({"description": "Human-readable element description used to obtain permission to interact with the element", "type": "string"}),
+        );
+        properties.insert(
+            "ref".to_string(),
+            json!({"description": "Exact target element reference from the page snapshot", "type": "string"}),
+        );
+        let schema_value = schema_from_props_and_required(properties, vec!["element", "ref"]);
+
+        let signature = schema_to_signature(&schema_value);
+        assert_eq!(signature, Some("(element: str, ref: str, button: Optional[str] = None, double_click: Optional[bool] = None)".to_string()));
+
+        let expected_docstring = indoc! {r#"
+            Args:
+                element: str: Human-readable element description used to obtain permission to interact with the element (required)
+                ref: str: Exact target element reference from the page snapshot (required)
+                button: Optional[str]: Button to click, defaults to left (allowed values: left, right, middle)
+                double_click: Optional[bool]: Whether to perform a double click instead of a single click
+        "#}.trim_end();
+        let docstring = schema_to_docstring_args(&schema_value);
+        assert_eq!(docstring, Some(expected_docstring.to_string()));
+    }
+
+    #[test]
+    fn test_screenshot_schema() {
+        let mut properties = serde_json::Map::new();
+        properties.insert(
+            "element".to_string(),
+            json!({"description": "Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.", "type": "string"}),
+        );
+        properties.insert(
+            "filename".to_string(),
+            json!({"description": "File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.", "type": "string"}),
+        );
+        properties.insert(
+            "fullPage".to_string(),
+            json!({"description": "When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.", "type": "boolean"}),
+        );
+        properties.insert(
+            "raw".to_string(),
+            json!({"description": "Whether to return without compression (in PNG format). Default is false, which returns a JPEG image.", "type": "boolean"}),
+        );
+        properties.insert(
+            "ref".to_string(),
+            json!({"description": "Exact target element reference from the page snapshot. If not provided, the screenshot will be taken of viewport. If ref is provided, element must be provided too.", "type": "string"}),
+        );
+        let schema_value = schema_from_props_and_required(properties, vec![]); // No required fields
+
+        let signature = schema_to_signature(&schema_value);
+        assert_eq!(signature, Some("(element: Optional[str] = None, filename: Optional[str] = None, full_page: Optional[bool] = None, raw: Optional[bool] = None, ref: Optional[str] = None)".to_string()));
+
+        let expected_docstring = indoc! {"
+            Args:
+                element: Optional[str]: Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.
+                filename: Optional[str]: File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.
+                full_page: Optional[bool]: When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.
+                raw: Optional[bool]: Whether to return without compression (in PNG format). Default is false, which returns a JPEG image.
+                ref: Optional[str]: Exact target element reference from the page snapshot. If not provided, the screenshot will be taken of viewport. If ref is provided, element must be provided too.
+        "}.trim_end();
+        let docstring = schema_to_docstring_args(&schema_value);
+        assert_eq!(docstring, Some(expected_docstring.to_string()));
+    }
+
+    #[test]
+    fn test_file_upload_schema() {
+        let mut properties = serde_json::Map::new();
+        properties.insert(
+            "paths".to_string(),
+            json!({
+                "description": "The absolute paths to the files to upload. Can be a single file or multiple files.",
+                "items": {"type": "string"},
+                "type": "array"
+            }),
+        );
+        let schema_value = schema_from_props_and_required(properties, vec!["paths"]);
+
+        let signature = schema_to_signature(&schema_value);
+        assert_eq!(signature, Some("(paths: List[str])".to_string()));
+
+        let expected_docstring = indoc! {"
+            Args:
+                paths: List[str]: The absolute paths to the files to upload. Can be a single file or multiple files. (required)
+        "}.trim_end();
+        let docstring = schema_to_docstring_args(&schema_value);
+        assert_eq!(docstring, Some(expected_docstring.to_string()));
+    }
+
+    #[test]
+    fn test_select_dropdown_schema() {
+        let mut properties = serde_json::Map::new();
+        properties.insert(
+            "element".to_string(),
+            json!({"description": "Human-readable element description used to obtain permission to interact with the element", "type": "string"}),
+        );
+        properties.insert(
+            "ref".to_string(),
+            json!({"description": "Exact target element reference from the page snapshot", "type": "string"}),
+        );
+        properties.insert(
+            "values".to_string(),
+            json!({
+                 "description": "Array of values to select in the dropdown. This can be a single value or multiple values.",
+                 "items": {"type": "string"},
+                 "type": "array"
+             }),
+        );
+        let schema_value =
+            schema_from_props_and_required(properties, vec!["element", "ref", "values"]);
+
+        let signature = schema_to_signature(&schema_value);
+        assert_eq!(
+            signature,
+            Some("(element: str, ref: str, values: List[str])".to_string())
+        );
+
+        let expected_docstring = indoc! {"
+            Args:
+                element: str: Human-readable element description used to obtain permission to interact with the element (required)
+                ref: str: Exact target element reference from the page snapshot (required)
+                values: List[str]: Array of values to select in the dropdown. This can be a single value or multiple values. (required)
+        "}.trim_end();
+        let docstring = schema_to_docstring_args(&schema_value);
+        assert_eq!(docstring, Some(expected_docstring.to_string()));
+    }
+
+    #[test]
+    fn test_extract_parameter_info_handles_missing_type() {
+        let prop_value: Value = json!({"description": "A param without type"});
+        // This test now targets the lower-level function `process_property`
+        let result = process_property("param", &prop_value, false);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extract_parameter_info_handles_non_object_property() {
+        let prop_value: Value = json!("just_a_string");
+        let result = process_property("param", &prop_value, false);
+        assert!(result.is_none());
+    }
+}

--- a/packages/fabricatio-tool/crates/signify/src/lib.rs
+++ b/packages/fabricatio-tool/crates/signify/src/lib.rs
@@ -244,7 +244,14 @@ mod tests {
             "type": "object"
         })
     }
-
+    #[test]
+    fn test_blank_schema(){
+        let schema_value = json!({"$schema":"http://json-schema.org/draft-07/schema#","additionalProperties":false,"properties":{},"type":"object"});
+        let signature = schema_to_signature(&schema_value);
+        assert_eq!(signature, Some("()".to_string()));
+        let docstring = schema_to_docstring_args(&schema_value);
+        assert_eq!(docstring, None);
+    }
     #[test]
     fn test_empty_schema() {
         let schema_value = schema_from_props_and_required(serde_json::Map::new(), vec![]);

--- a/packages/fabricatio-tool/pyproject.toml
+++ b/packages/fabricatio-tool/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio-tool"
-version = "0.5.1"
+version = "0.5.2-dev0"
 description = "An extension of fabricatio, which brings up the capability to use tool with native python."
 readme = "README.md"
 authors = [

--- a/packages/fabricatio-tool/pyproject.toml
+++ b/packages/fabricatio-tool/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio-tool"
-version = "0.5.0"
+version = "0.5.1-dev1"
 description = "An extension of fabricatio, which brings up the capability to use tool with native python."
 readme = "README.md"
 authors = [

--- a/packages/fabricatio-tool/pyproject.toml
+++ b/packages/fabricatio-tool/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio-tool"
-version = "0.5.2-dev1"
+version = "0.5.2-dev2"
 description = "An extension of fabricatio, which brings up the capability to use tool with native python."
 readme = "README.md"
 authors = [

--- a/packages/fabricatio-tool/pyproject.toml
+++ b/packages/fabricatio-tool/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio-tool"
-version = "0.6.0"
+version = "0.6.1"
 description = "An extension of fabricatio, which brings up the capability to use tool with native python."
 readme = "README.md"
 authors = [

--- a/packages/fabricatio-tool/pyproject.toml
+++ b/packages/fabricatio-tool/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio-tool"
-version = "0.5.2-dev0"
+version = "0.5.2-dev1"
 description = "An extension of fabricatio, which brings up the capability to use tool with native python."
 readme = "README.md"
 authors = [

--- a/packages/fabricatio-tool/pyproject.toml
+++ b/packages/fabricatio-tool/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio-tool"
-version = "0.5.1-dev1"
+version = "0.5.1-dev2"
 description = "An extension of fabricatio, which brings up the capability to use tool with native python."
 readme = "README.md"
 authors = [

--- a/packages/fabricatio-tool/pyproject.toml
+++ b/packages/fabricatio-tool/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio-tool"
-version = "0.5.1-dev2"
+version = "0.5.1"
 description = "An extension of fabricatio, which brings up the capability to use tool with native python."
 readme = "README.md"
 authors = [

--- a/packages/fabricatio-tool/pyproject.toml
+++ b/packages/fabricatio-tool/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio-tool"
-version = "0.5.2-dev2"
+version = "0.5.2-dev3"
 description = "An extension of fabricatio, which brings up the capability to use tool with native python."
 readme = "README.md"
 authors = [

--- a/packages/fabricatio-tool/pyproject.toml
+++ b/packages/fabricatio-tool/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio-tool"
-version = "0.5.2-dev3"
+version = "0.6.0"
 description = "An extension of fabricatio, which brings up the capability to use tool with native python."
 readme = "README.md"
 authors = [

--- a/packages/fabricatio-tool/python/fabricatio_tool/mcp.py
+++ b/packages/fabricatio-tool/python/fabricatio_tool/mcp.py
@@ -2,12 +2,12 @@
 
 from typing import Any, Callable, Coroutine, Dict, List
 
-from fabricatio_tool.rust import MCPManager
-
 from fabricatio_core import logger
 from fabricatio_core.decorators import once
+
 from fabricatio_tool.config import ServiceConfig, tool_config
 from fabricatio_tool.models.tool import ToolBox
+from fabricatio_tool.rust import MCPManager
 
 
 @once
@@ -52,20 +52,19 @@ async def mcp_tool_to_function(client_id: str, tool_name: str) -> Callable[..., 
     raise ValueError(f"Tool {tool_name} not found")
 
 
-
 async def mcp_to_toolbox(client_id: str) -> ToolBox:
     """Converts all tools from a specified MCP client into a ToolBox.
-    
+
     This function retrieves all available tools from the given MCP client,
     converts each tool into a callable async function, and adds them to
     a ToolBox instance.
-    
+
     Args:
         client_id: Identifier for the client/service hosting the tools
-        
+
     Returns:
         ToolBox: A toolbox containing all tools from the specified client
-        
+
     Raises:
         ValueError: If the specified client cannot be found
     """
@@ -74,8 +73,7 @@ async def mcp_to_toolbox(client_id: str) -> ToolBox:
     if not man.has_client(client_id):
         raise ValueError(f"Client {client_id} not found")
 
-
-    toolbox= ToolBox(name=client_id)
+    toolbox = ToolBox(name=client_id)
 
     for tool in await man.list_tool_names(client_id):
         func = await mcp_tool_to_function(client_id, tool)

--- a/packages/fabricatio-tool/python/fabricatio_tool/mcp.py
+++ b/packages/fabricatio-tool/python/fabricatio_tool/mcp.py
@@ -2,11 +2,12 @@
 
 from typing import Any, Callable, Coroutine, Dict, List
 
+from fabricatio_tool.rust import MCPManager
+
 from fabricatio_core import logger
 from fabricatio_core.decorators import once
-
 from fabricatio_tool.config import ServiceConfig, tool_config
-from fabricatio_tool.rust import MCPManager
+from fabricatio_tool.models.tool import ToolBox
 
 
 @once
@@ -49,3 +50,35 @@ async def mcp_tool_to_function(client_id: str, tool_name: str) -> Callable[..., 
         f: Callable[..., Coroutine[Any, Any, List[str]]] = d.get(t.name)  # pyright: ignore [reportAssignmentType]
         return f
     raise ValueError(f"Tool {tool_name} not found")
+
+
+
+async def mcp_to_toolbox(client_id: str) -> ToolBox:
+    """Converts all tools from a specified MCP client into a ToolBox.
+    
+    This function retrieves all available tools from the given MCP client,
+    converts each tool into a callable async function, and adds them to
+    a ToolBox instance.
+    
+    Args:
+        client_id: Identifier for the client/service hosting the tools
+        
+    Returns:
+        ToolBox: A toolbox containing all tools from the specified client
+        
+    Raises:
+        ValueError: If the specified client cannot be found
+    """
+    man = await get_global_mcp_manager()
+
+    if not man.has_client(client_id):
+        raise ValueError(f"Client {client_id} not found")
+
+
+    toolbox= ToolBox(name=client_id)
+
+    for tool in await man.list_tool_names(client_id):
+        func = await mcp_tool_to_function(client_id, tool)
+        toolbox.add_tool(func)
+
+    return toolbox

--- a/packages/fabricatio-tool/python/fabricatio_tool/mcp.py
+++ b/packages/fabricatio-tool/python/fabricatio_tool/mcp.py
@@ -1,14 +1,55 @@
 """MCP (Model Context Protocol) management utilities."""
 
-from typing import Dict
+from functools import wraps
+from typing import Any, Callable, Coroutine, Dict, List
+
+from fabricatio_tool.rust import MCPManager
 
 from fabricatio_core.decorators import once
-
 from fabricatio_tool.config import ServiceConfig, tool_config
-from fabricatio_tool.rust import MCPManager
 
 
 @once
 async def get_global_mcp_manager(conf: Dict[str, ServiceConfig] = tool_config.mcp_servers) -> MCPManager:
     """Get the global MCP manager instance."""
     return await MCPManager.create(conf)
+
+
+async def mcp_tool_to_function(client_id: str, tool_name: str) -> Callable[..., Coroutine[Any, Any, List[str]]]:
+    """Converts a registered MCP tool into a callable async function.
+
+    This function dynamically generates and returns an async function that wraps
+    the specified tool's execution. The generated function will have:
+    - A signature derived from the tool's input schema
+    - A docstring containing the tool description and parameter documentation
+    - Execution that delegates to the MCP manager's call_tool method
+
+    Args:
+        client_id: Identifier for the client/service hosting the tool
+        tool_name: Name of the tool to convert to a function
+
+    Returns:
+        Coroutine-enabled function that accepts keyword arguments matching the tool's
+        input schema and returns a list of execution result strings
+
+    Raises:
+        ValueError: If the specified tool cannot be found
+
+    Notes:
+        The generated function uses functools.wraps to preserve metadata and will
+        raise if called with invalid arguments based on the tool's schema
+    """
+    man = await get_global_mcp_manager()
+
+    if (t := await man.get_tool(client_id, tool_name)) is not None:
+        n = t.name
+        exec(t.function_string, locals())  # noqa: S102
+        f: Callable[..., List[str]] = locals().get(n)  # pyright: ignore [reportAssignmentType]
+
+        @wraps(f)
+        async def _inner(**kwargs) -> List[str]:
+            return await man.call_tool(client_id, tool_name, kwargs)
+
+        return _inner
+
+    raise ValueError(f"Tool {tool_name} not found")

--- a/packages/fabricatio-tool/python/fabricatio_tool/rust.pyi
+++ b/packages/fabricatio-tool/python/fabricatio_tool/rust.pyi
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Literal, Optional, Set
 
 from pydantic import JsonValue
 
-
 class CheckConfig:
     def __init__(self, targets: Set[str], mode: Literal["whitelist", "blacklist"]) -> None:
         """Initialize a CheckConfig instance with specified targets and mode.
@@ -91,7 +90,7 @@ class ToolMetaData:
         Returns:
             Formatted async function signature with input parameters and return type.
         """
-    
+
     @property
     def function_docstring(self) -> str:
         """Python docstring template for this tool's generated function.
@@ -102,7 +101,7 @@ class ToolMetaData:
     @property
     def function_string(self) -> str:
         """Complete Python function template for this tool's implementation.
-        
+
         Returns:
             String containing full async function definition with formatted
             signature, docstring, and return type annotation.
@@ -127,6 +126,17 @@ class MCPManager:
 
         Returns:
             A list of ToolMetaData instances representing available tools.
+        """
+
+    async def get_tool(self, client_id: str, tool_name: str) -> Optional[ToolMetaData]:
+        """Retrieves metadata for a specific tool from a client.
+
+        Args:
+            client_id: The ID of the client to retrieve the tool from
+            tool_name: The name of the tool to retrieve
+
+        Returns:
+            The requested tool's metadata if found
         """
 
     async def call_tool(self, client_id: str, tool_name: str, arguments: Optional[Dict[str, Any]] = None) -> List[str]:

--- a/packages/fabricatio-tool/python/fabricatio_tool/rust.pyi
+++ b/packages/fabricatio-tool/python/fabricatio_tool/rust.pyi
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Literal, Optional, Set
 
 from pydantic import JsonValue
 
-
 class CheckConfig:
     def __init__(self, targets: Set[str], mode: Literal["whitelist", "blacklist"]) -> None:
         """Initialize a CheckConfig instance with specified targets and mode.
@@ -195,7 +194,6 @@ class MCPManager:
         Returns:
             True if the server is reachable, False otherwise.
         """
-
 
     def has_client(self, client_id: str) -> bool:
         """Check if a client exists in the manager.

--- a/packages/fabricatio-tool/python/fabricatio_tool/rust.pyi
+++ b/packages/fabricatio-tool/python/fabricatio_tool/rust.pyi
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Literal, Optional, Set
 
 from pydantic import JsonValue
 
+
 class CheckConfig:
     def __init__(self, targets: Set[str], mode: Literal["whitelist", "blacklist"]) -> None:
         """Initialize a CheckConfig instance with specified targets and mode.
@@ -81,6 +82,30 @@ class ToolMetaData:
 
         Serialized version of annotations property. Offers machine-readable
         access to implementation-specific details in string format.
+        """
+
+    @property
+    def function_header(self) -> str:
+        """Python function signature string for this tool.
+
+        Returns:
+            Formatted async function signature with input parameters and return type.
+        """
+    
+    @property
+    def function_docstring(self) -> str:
+        """Python docstring template for this tool's generated function.
+
+        Returns:
+            Pre-formatted docstring with argument descriptions and return documentation.
+        """
+    @property
+    def function_string(self) -> str:
+        """Complete Python function template for this tool's implementation.
+        
+        Returns:
+            String containing full async function definition with formatted
+            signature, docstring, and return type annotation.
         """
 
 class MCPManager:

--- a/packages/fabricatio-tool/python/fabricatio_tool/rust.pyi
+++ b/packages/fabricatio-tool/python/fabricatio_tool/rust.pyi
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Literal, Optional, Set
 
 from pydantic import JsonValue
 
+
 class CheckConfig:
     def __init__(self, targets: Set[str], mode: Literal["whitelist", "blacklist"]) -> None:
         """Initialize a CheckConfig instance with specified targets and mode.
@@ -193,4 +194,26 @@ class MCPManager:
 
         Returns:
             True if the server is reachable, False otherwise.
+        """
+
+
+    def has_client(self, client_id: str) -> bool:
+        """Check if a client exists in the manager.
+
+        Args:
+            client_id: The ID of the client to check.
+
+        Returns:
+            True if the client exists, False otherwise.
+        """
+
+    async def has_tool(self, client_id: str, tool_name: str) -> bool:
+        """Check if a tool exists for a specific client.
+
+        Args:
+            client_id: The ID of the client.
+            tool_name: The name of the tool.
+
+        Returns:
+            True if the tool exists, False otherwise.
         """

--- a/packages/fabricatio-tool/src/mcp.rs
+++ b/packages/fabricatio-tool/src/mcp.rs
@@ -273,6 +273,38 @@ impl MCPManager {
             }))
         })
     }
+
+    /// Checks if a client exists in the manager
+    ///
+    /// # Arguments
+    /// * `client_id` - The ID of the client to check
+    ///
+    /// # Returns
+    /// * `bool` - True if the client exists, false otherwise
+    fn has_client(&self, client_id: String) -> bool {
+        self.inner.has_client(client_id.as_str())
+    }
+
+    /// Checks if a tool exists for a specific client
+    ///
+    /// # Arguments
+    /// * `client_id` - The ID of the client
+    /// * `tool_name` - The name of the tool to check
+    ///
+    /// # Returns
+    /// * `PyResult<bool>` - True if the tool exists, false otherwise, or an error if the operation fails
+    pub fn has_tool<'a>(&self,python: Python<'a>, client_id: String, tool_name: String) -> PyResult<Bound<'a, PyAny>> {
+
+        let inner = self.inner.clone();
+
+        future_into_py(python, async move {
+            inner
+                .has_tool(client_id.as_str(), tool_name.as_str())
+                .await
+                .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+        })
+
+    }
 }
 
 /// Registers Python module components

--- a/packages/fabricatio-tool/src/mcp.rs
+++ b/packages/fabricatio-tool/src/mcp.rs
@@ -293,8 +293,12 @@ impl MCPManager {
     ///
     /// # Returns
     /// * `PyResult<bool>` - True if the tool exists, false otherwise, or an error if the operation fails
-    pub fn has_tool<'a>(&self,python: Python<'a>, client_id: String, tool_name: String) -> PyResult<Bound<'a, PyAny>> {
-
+    pub fn has_tool<'a>(
+        &self,
+        python: Python<'a>,
+        client_id: String,
+        tool_name: String,
+    ) -> PyResult<Bound<'a, PyAny>> {
         let inner = self.inner.clone();
 
         future_into_py(python, async move {
@@ -303,7 +307,6 @@ impl MCPManager {
                 .await
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))
         })
-
     }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricatio"
-version = "0.18.1"
+version = "0.19.0"
 description = "A LLM multi-agent framework."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -406,7 +406,7 @@ wheels = [
 
 [[package]]
 name = "fabricatio"
-version = "0.18.1"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "fabricatio-core" },
@@ -1110,7 +1110,7 @@ dev = [{ name = "pytest" }]
 
 [[package]]
 name = "fabricatio-tool"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "packages/fabricatio-tool" }
 dependencies = [
     { name = "fabricatio-core" },
@@ -1339,28 +1339,30 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.67.1"
+version = "1.74.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/20/53/d9282a66a5db45981499190b77790570617a604a38f3d103d0400974aeb5/grpcio-1.67.1.tar.gz", hash = "sha256:3dc2ed4cabea4dc14d5e708c2b426205956077cc5de419b4d4079315017e9732" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/38/b4/35feb8f7cab7239c5b94bd2db71abb3d6adb5f335ad8f131abb6060840b6/grpcio-1.74.0.tar.gz", hash = "sha256:80d1f4fbb35b0742d3e3d3bb654b7381cd5f015f8497279a1e9c21ba623e01b1" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/6e/25/6f95bd18d5f506364379eabc0d5874873cc7dbdaf0757df8d1e82bc07a88/grpcio-1.67.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:267d1745894200e4c604958da5f856da6293f063327cb049a51fe67348e4f953" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/10/3f/d79e32e5d0354be33a12db2267c66d3cfeff700dd5ccdd09fd44a3ff4fb6/grpcio-1.67.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:85f69fdc1d28ce7cff8de3f9c67db2b0ca9ba4449644488c1e0303c146135ddb" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/21/f2/36fbc14b3542e3a1c20fb98bd60c4732c55a44e374a4eb68f91f28f14aab/grpcio-1.67.1-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:f26b0b547eb8d00e195274cdfc63ce64c8fc2d3e2d00b12bf468ece41a0423a0" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/0d/af/bbc1305df60c4e65de8c12820a942b5e37f9cf684ef5e49a63fbb1476a73/grpcio-1.67.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4422581cdc628f77302270ff839a44f4c24fdc57887dc2a45b7e53d8fc2376af" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/92/cf/1d4c3e93efa93223e06a5c83ac27e32935f998bc368e276ef858b8883154/grpcio-1.67.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1d7616d2ded471231c701489190379e0c311ee0a6c756f3c03e6a62b95a7146e" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/ae/ca/26195b66cb253ac4d5ef59846e354d335c9581dba891624011da0e95d67b/grpcio-1.67.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8a00efecde9d6fcc3ab00c13f816313c040a28450e5e25739c24f432fc6d3c75" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/d1/94/16550ad6b3f13b96f0856ee5dfc2554efac28539ee84a51d7b14526da985/grpcio-1.67.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:699e964923b70f3101393710793289e42845791ea07565654ada0969522d0a38" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/33/0d/4c3b2587e8ad7f121b597329e6c2620374fccbc2e4e1aa3c73ccc670fde4/grpcio-1.67.1-cp312-cp312-win32.whl", hash = "sha256:4e7b904484a634a0fff132958dabdb10d63e0927398273917da3ee103e8d1f78" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/7d/36/0c03e2d80db69e2472cf81c6123aa7d14741de7cf790117291a703ae6ae1/grpcio-1.67.1-cp312-cp312-win_amd64.whl", hash = "sha256:5721e66a594a6c4204458004852719b38f3d5522082be9061d6510b455c90afc" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/12/d2/2f032b7a153c7723ea3dea08bffa4bcaca9e0e5bdf643ce565b76da87461/grpcio-1.67.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:aa0162e56fd10a5547fac8774c4899fc3e18c1aa4a4759d0ce2cd00d3696ea6b" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/d0/ae/ea2ff6bd2475a082eb97db1104a903cf5fc57c88c87c10b3c3f41a184fc0/grpcio-1.67.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:beee96c8c0b1a75d556fe57b92b58b4347c77a65781ee2ac749d550f2a365dc1" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/07/62/646be83d1a78edf8d69b56647327c9afc223e3140a744c59b25fbb279c3b/grpcio-1.67.1-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:a93deda571a1bf94ec1f6fcda2872dad3ae538700d94dc283c672a3b508ba3af" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/d0/25/71513d0a1b2072ce80d7f5909a93596b7ed10348b2ea4fdcbad23f6017bf/grpcio-1.67.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e6f255980afef598a9e64a24efce87b625e3e3c80a45162d111a461a9f92955" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/76/9a/d21236297111052dcb5dc85cd77dc7bf25ba67a0f55ae028b2af19a704bc/grpcio-1.67.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e838cad2176ebd5d4a8bb03955138d6589ce9e2ce5d51c3ada34396dbd2dba8" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/2d/fe/70b1da9037f5055be14f359026c238821b9bcf6ca38a8d760f59a589aacd/grpcio-1.67.1-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:a6703916c43b1d468d0756c8077b12017a9fcb6a1ef13faf49e67d20d7ebda62" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/74/0d/7df509a2cd2a54814598caf2fb759f3e0b93764431ff410f2175a6efb9e4/grpcio-1.67.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:917e8d8994eed1d86b907ba2a61b9f0aef27a2155bca6cbb322430fc7135b7bb" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/0a/08/bc3b0155600898fd10f16b79054e1cca6cb644fa3c250c0fe59385df5e6f/grpcio-1.67.1-cp313-cp313-win32.whl", hash = "sha256:e279330bef1744040db8fc432becc8a727b84f456ab62b744d3fdb83f327e121" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/5a/96/44759eca966720d0f3e1b105c43f8ad4590c97bf8eb3cd489656e9590baa/grpcio-1.67.1-cp313-cp313-win_amd64.whl", hash = "sha256:fa0c739ad8b1996bd24823950e3cb5152ae91fca1c09cc791190bf1627ffefba" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/4c/5d/e504d5d5c4469823504f65687d6c8fb97b7f7bf0b34873b7598f1df24630/grpcio-1.74.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:8533e6e9c5bd630ca98062e3a1326249e6ada07d05acf191a77bc33f8948f3d8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/43/01/730e37056f96f2f6ce9f17999af1556df62ee8dab7fa48bceeaab5fd3008/grpcio-1.74.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:2918948864fec2a11721d91568effffbe0a02b23ecd57f281391d986847982f6" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/79/3d/09fd100473ea5c47083889ca47ffd356576173ec134312f6aa0e13111dee/grpcio-1.74.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:60d2d48b0580e70d2e1954d0d19fa3c2e60dd7cbed826aca104fff518310d1c5" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/8a/99/12d2cca0a63c874c6d3d195629dcd85cdf5d6f98a30d8db44271f8a97b93/grpcio-1.74.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3601274bc0523f6dc07666c0e01682c94472402ac2fd1226fd96e079863bfa49" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/9d/2c/930b0e7a2f1029bbc193443c7bc4dc2a46fedb0203c8793dcd97081f1520/grpcio-1.74.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:176d60a5168d7948539def20b2a3adcce67d72454d9ae05969a2e73f3a0feee7" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/db/d5/ff8a2442180ad0867717e670f5ec42bfd8d38b92158ad6bcd864e6d4b1ed/grpcio-1.74.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e759f9e8bc908aaae0412642afe5416c9f983a80499448fcc7fab8692ae044c3" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b0/ba/b361d390451a37ca118e4ec7dccec690422e05bc85fba2ec72b06cefec9f/grpcio-1.74.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:9e7c4389771855a92934b2846bd807fc25a3dfa820fd912fe6bd8136026b2707" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/3b/0c/3a5fa47d2437a44ced74141795ac0251bbddeae74bf81df3447edd767d27/grpcio-1.74.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cce634b10aeab37010449124814b05a62fb5f18928ca878f1bf4750d1f0c815b" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ae/95/ab64703b436d99dc5217228babc76047d60e9ad14df129e307b5fec81fd0/grpcio-1.74.0-cp312-cp312-win32.whl", hash = "sha256:885912559974df35d92219e2dc98f51a16a48395f37b92865ad45186f294096c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/84/59/900aa2445891fc47a33f7d2f76e00ca5d6ae6584b20d19af9c06fa09bf9a/grpcio-1.74.0-cp312-cp312-win_amd64.whl", hash = "sha256:42f8fee287427b94be63d916c90399ed310ed10aadbf9e2e5538b3e497d269bc" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d4/d8/1004a5f468715221450e66b051c839c2ce9a985aa3ee427422061fcbb6aa/grpcio-1.74.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:2bc2d7d8d184e2362b53905cb1708c84cb16354771c04b490485fa07ce3a1d89" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/94/0e/33731a03f63740d7743dced423846c831d8e6da808fcd02821a4416df7fa/grpcio-1.74.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c14e803037e572c177ba54a3e090d6eb12efd795d49327c5ee2b3bddb836bf01" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/0d/c6/3d2c14d87771a421205bdca991467cfe473ee4c6a1231c1ede5248c62ab8/grpcio-1.74.0-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:f6ec94f0e50eb8fa1744a731088b966427575e40c2944a980049798b127a687e" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/c5/83/5a354c8aaff58594eef7fffebae41a0f8995a6258bbc6809b800c33d4c13/grpcio-1.74.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:566b9395b90cc3d0d0c6404bc8572c7c18786ede549cdb540ae27b58afe0fb91" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/3f/ca/4fdc7bf59bf6994aa45cbd4ef1055cd65e2884de6113dbd49f75498ddb08/grpcio-1.74.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1ea6176d7dfd5b941ea01c2ec34de9531ba494d541fe2057c904e601879f249" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/fd/48/2869e5b2c1922583686f7ae674937986807c2f676d08be70d0a541316270/grpcio-1.74.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:64229c1e9cea079420527fa8ac45d80fc1e8d3f94deaa35643c381fa8d98f362" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a6/0e/bac93147b9a164f759497bc6913e74af1cb632c733c7af62c0336782bd38/grpcio-1.74.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:0f87bddd6e27fc776aacf7ebfec367b6d49cad0455123951e4488ea99d9b9b8f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/84/35/9f6b2503c1fd86d068b46818bbd7329db26a87cdd8c01e0d1a9abea1104c/grpcio-1.74.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3b03d8f2a07f0fea8c8f74deb59f8352b770e3900d143b3d1475effcb08eec20" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/75/33/a04e99be2a82c4cbc4039eb3a76f6c3632932b9d5d295221389d10ac9ca7/grpcio-1.74.0-cp313-cp313-win32.whl", hash = "sha256:b6a73b2ba83e663b2480a90b82fdae6a7aa6427f62bf43b29912c0cfd1aa2bfa" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/34/80/de3eb55eb581815342d097214bed4c59e806b05f1b3110df03b2280d6dfd/grpcio-1.74.0-cp313-cp313-win_amd64.whl", hash = "sha256:fd3c71aeee838299c5887230b8a1822795325ddfea635edd82954c1eaa831e24" },
 ]
 
 [[package]]
@@ -2369,7 +2371,7 @@ wheels = [
 
 [[package]]
 name = "pymilvus"
-version = "2.5.14"
+version = "2.6.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
 dependencies = [
     { name = "grpcio" },
@@ -2380,9 +2382,9 @@ dependencies = [
     { name = "setuptools" },
     { name = "ujson" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/bb/f5/ab9309bd59d141d7977512b870eb5286ec80ced450ecdc5580b06f5fdf1a/pymilvus-2.5.14.tar.gz", hash = "sha256:ba831aa79d29feb3a5ff846c07a59015d0f995949d0dfd2f420554cda0261b98" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/86/21/5c25a975299415a5a8f26d4759ddf7852aefdf3595f002b5203c4aaf5c8e/pymilvus-2.6.0.tar.gz", hash = "sha256:2b2ca487e098abc34231755e33af2f5294e9f6a64d92d03551532defbac0a3fb" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/58/39/e6574fa640583e33ab6e709d61bbad315130ca42dcbf449aa025c3789a63/pymilvus-2.5.14-py3-none-any.whl", hash = "sha256:0e3cb687fd0807770cafb59566d217998b2166edcfa11956dd6e3fbbe2136a0f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/f6/a2/dfc2a2225aeb90a7dff9443f2d26fe9d04f6f7bcefe537945b5d5220fddd/pymilvus-2.6.0-py3-none-any.whl", hash = "sha256:d743fdd928c9007184d24a52b4f5dfdd18d405a37b4dba66b5ea4bf196fac526" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -739,7 +739,7 @@ dev = [{ name = "pytest" }]
 
 [[package]]
 name = "fabricatio-core"
-version = "0.3.23"
+version = "0.3.24.dev0"
 source = { editable = "packages/fabricatio-core" }
 dependencies = [
     { name = "asyncio" },

--- a/uv.lock
+++ b/uv.lock
@@ -739,7 +739,7 @@ dev = [{ name = "pytest" }]
 
 [[package]]
 name = "fabricatio-core"
-version = "0.3.24.dev0"
+version = "0.3.24"
 source = { editable = "packages/fabricatio-core" }
 dependencies = [
     { name = "asyncio" },
@@ -1110,7 +1110,7 @@ dev = [{ name = "pytest" }]
 
 [[package]]
 name = "fabricatio-tool"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/fabricatio-tool" }
 dependencies = [
     { name = "fabricatio-core" },
@@ -1374,17 +1374,17 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.1.5"
+version = "1.1.7"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/ed/d4/7685999e85945ed0d7f0762b686ae7015035390de1161dcea9d5276c134c/hf_xet-1.1.5.tar.gz", hash = "sha256:69ebbcfd9ec44fdc2af73441619eeb06b94ee34511bbcf57cd423820090f5694" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/b2/0a/a0f56735940fde6dd627602fec9ab3bad23f66a272397560abd65aba416e/hf_xet-1.1.7.tar.gz", hash = "sha256:20cec8db4561338824a3b5f8c19774055b04a8df7fff0cb1ff2cb1a0c1607b80" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/00/89/a1119eebe2836cb25758e7661d6410d3eae982e2b5e974bcc4d250be9012/hf_xet-1.1.5-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f52c2fa3635b8c37c7764d8796dfa72706cc4eded19d638331161e82b0792e23" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/de/5f/2c78e28f309396e71ec8e4e9304a6483dcbc36172b5cea8f291994163425/hf_xet-1.1.5-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:9fa6e3ee5d61912c4a113e0708eaaef987047616465ac7aa30f7121a48fc1af8" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/6d/2f/6cad7b5fe86b7652579346cb7f85156c11761df26435651cbba89376cd2c/hf_xet-1.1.5-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc874b5c843e642f45fd85cda1ce599e123308ad2901ead23d3510a47ff506d1" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/d0/54/0fcf2b619720a26fbb6cc941e89f2472a522cd963a776c089b189559447f/hf_xet-1.1.5-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dbba1660e5d810bd0ea77c511a99e9242d920790d0e63c0e4673ed36c4022d18" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/f3/92/1d351ac6cef7c4ba8c85744d37ffbfac2d53d0a6c04d2cabeba614640a78/hf_xet-1.1.5-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ab34c4c3104133c495785d5d8bba3b1efc99de52c02e759cf711a91fd39d3a14" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/c9/65/4b2ddb0e3e983f2508528eb4501288ae2f84963586fbdfae596836d5e57a/hf_xet-1.1.5-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:83088ecea236d5113de478acb2339f92c95b4fb0462acaa30621fac02f5a534a" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/f0/55/ef77a85ee443ae05a9e9cba1c9f0dd9241eb42da2aeba1dc50f51154c81a/hf_xet-1.1.5-cp37-abi3-win_amd64.whl", hash = "sha256:73e167d9807d166596b4b2f0b585c6d5bd84a26dea32843665a8b58f6edba245" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b1/7c/8d7803995caf14e7d19a392a486a040f923e2cfeff824e9b800b92072f76/hf_xet-1.1.7-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:60dae4b44d520819e54e216a2505685248ec0adbdb2dd4848b17aa85a0375cde" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/51/a3/fa5897099454aa287022a34a30e68dbff0e617760f774f8bd1db17f06bd4/hf_xet-1.1.7-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:b109f4c11e01c057fc82004c9e51e6cdfe2cb230637644ade40c599739067b2e" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/86/50/2446a132267e60b8a48b2e5835d6e24fd988000d0f5b9b15ebd6d64ef769/hf_xet-1.1.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6efaaf1a5a9fc3a501d3e71e88a6bfebc69ee3a716d0e713a931c8b8d920038f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/20/8f/ccc670616bb9beee867c6bb7139f7eab2b1370fe426503c25f5cbb27b148/hf_xet-1.1.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:751571540f9c1fbad9afcf222a5fb96daf2384bf821317b8bfb0c59d86078513" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/21/0a/4c30e1eb77205565b854f5e4a82cf1f056214e4dc87f2918ebf83d47ae14/hf_xet-1.1.7-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:18b61bbae92d56ae731b92087c44efcac216071182c603fc535f8e29ec4b09b8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/f5/1e/fc7e9baf14152662ef0b35fa52a6e889f770a7ed14ac239de3c829ecb47e/hf_xet-1.1.7-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:713f2bff61b252f8523739969f247aa354ad8e6d869b8281e174e2ea1bb8d604" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a3/73/e354eae84ceff117ec3560141224724794828927fcc013c5b449bf0b8745/hf_xet-1.1.7-cp37-abi3-win_amd64.whl", hash = "sha256:2e356da7d284479ae0f1dea3cf5a2f74fdf925d6dca84ac4341930d892c7cb34" },
 ]
 
 [[package]]
@@ -1662,7 +1662,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.74.15.post1"
+version = "1.75.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
 dependencies = [
     { name = "aiohttp" },
@@ -1677,7 +1677,10 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/3e/fc/02bfc7dcf6276fbbd5acf0ebcb188f824cf6d4ee8013d7150458c77c7047/litellm-1.74.15.post1.tar.gz", hash = "sha256:8c0f73f89f15603afebbc912cb30ba6f18439eb12249f16a37646752fb76825e" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/1b/28/50837cb0246c42a8caac45610572883de7f478543cf4d143e84f099c0234/litellm-1.75.0.tar.gz", hash = "sha256:ec7fbfe79e1b9cd4a2b36ca9e71e71959d8fc43305b222e5f257aced1a0d1d63" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/db/43/e10905870d42e927de3b095a9248f2764156c7eb45ec172d72be35cd2bb4/litellm-1.75.0-py3-none-any.whl", hash = "sha256:1657472f37d291b366050dd2035e3640eebd96142d6fa0f935ceb290a0e1d5ad" },
+]
 
 [[package]]
 name = "loguru"
@@ -2052,7 +2055,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.98.0"
+version = "1.99.1"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
 dependencies = [
     { name = "anyio" },
@@ -2064,9 +2067,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/d8/9d/52eadb15c92802711d6b6cf00df3a6d0d18b588f4c5ba5ff210c6419fc03/openai-1.98.0.tar.gz", hash = "sha256:3ee0fcc50ae95267fd22bd1ad095ba5402098f3df2162592e68109999f685427" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/03/30/f0fb7907a77e733bb801c7bdcde903500b31215141cdb261f04421e6fbec/openai-1.99.1.tar.gz", hash = "sha256:2c9d8e498c298f51bb94bcac724257a3a6cac6139ccdfc1186c6708f7a93120f" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/a8/fe/f64631075b3d63a613c0d8ab761d5941631a470f6fa87eaaee1aa2b4ec0c/openai-1.98.0-py3-none-any.whl", hash = "sha256:b99b794ef92196829120e2df37647722104772d2a74d08305df9ced5f26eae34" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/54/15/9c85154ffd283abfc43309ff3aaa63c3fd02f7767ee684e73670f6c5ade2/openai-1.99.1-py3-none-any.whl", hash = "sha256:8eeccc69e0ece1357b51ca0d9fb21324afee09b20c3e5b547d02445ca18a4e03" },
 ]
 
 [[package]]
@@ -3018,26 +3021,26 @@ wheels = [
 
 [[package]]
 name = "tiktoken"
-version = "0.9.0"
+version = "0.10.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
 dependencies = [
     { name = "regex" },
     { name = "requests" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/ea/cf/756fedf6981e82897f2d570dd25fa597eb3f4459068ae0572d7e888cfd6f/tiktoken-0.9.0.tar.gz", hash = "sha256:d02a5ca6a938e0490e1ff957bc48c8b078c88cb83977be1625b1fd8aac792c5d" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/fd/6a/e0f66d5cf612979fec2c18f9069962c73ed51949403967ba0de9ea6859e5/tiktoken-0.10.0.tar.gz", hash = "sha256:7cd88c11699b18081822e6ae1beee55e8f20ea361d73c507d33f5a89a1898f1c" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/cf/e5/21ff33ecfa2101c1bb0f9b6df750553bd873b7fb532ce2cb276ff40b197f/tiktoken-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e88f121c1c22b726649ce67c089b90ddda8b9662545a8aeb03cfef15967ddd03" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/8e/03/a95e7b4863ee9ceec1c55983e4cc9558bcfd8f4f80e19c4f8a99642f697d/tiktoken-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a6600660f2f72369acb13a57fb3e212434ed38b045fd8cc6cdd74947b4b5d210" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/40/10/1305bb02a561595088235a513ec73e50b32e74364fef4de519da69bc8010/tiktoken-0.9.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95e811743b5dfa74f4b227927ed86cbc57cad4df859cb3b643be797914e41794" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/1b/40/da42522018ca496432ffd02793c3a72a739ac04c3794a4914570c9bb2925/tiktoken-0.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99376e1370d59bcf6935c933cb9ba64adc29033b7e73f5f7569f3aad86552b22" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/5c/41/1e59dddaae270ba20187ceb8aa52c75b24ffc09f547233991d5fd822838b/tiktoken-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:badb947c32739fb6ddde173e14885fb3de4d32ab9d8c591cbd013c22b4c31dd2" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/5b/64/b16003419a1d7728d0d8c0d56a4c24325e7b10a21a9dd1fc0f7115c02f0a/tiktoken-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:5a62d7a25225bafed786a524c1b9f0910a1128f4232615bf3f8257a73aaa3b16" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/7a/11/09d936d37f49f4f494ffe660af44acd2d99eb2429d60a57c71318af214e0/tiktoken-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b0e8e05a26eda1249e824156d537015480af7ae222ccb798e5234ae0285dbdb" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/80/0e/f38ba35713edb8d4197ae602e80837d574244ced7fb1b6070b31c29816e0/tiktoken-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:27d457f096f87685195eea0165a1807fae87b97b2161fe8c9b1df5bd74ca6f63" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/fe/82/9197f77421e2a01373e27a79dd36efdd99e6b4115746ecc553318ecafbf0/tiktoken-0.9.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cf8ded49cddf825390e36dd1ad35cd49589e8161fdcb52aa25f0583e90a3e01" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/f2/bb/4513da71cac187383541facd0291c4572b03ec23c561de5811781bbd988f/tiktoken-0.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc156cb314119a8bb9748257a2eaebd5cc0753b6cb491d26694ed42fc7cb3139" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/fa/5c/74e4c137530dd8504e97e3a41729b1103a4ac29036cbfd3250b11fd29451/tiktoken-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cd69372e8c9dd761f0ab873112aba55a0e3e506332dd9f7522ca466e817b1b7a" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/de/a8/8f499c179ec900783ffe133e9aab10044481679bb9aad78436d239eee716/tiktoken-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5ea0edb6f83dc56d794723286215918c1cde03712cbbafa0348b33448faf5b95" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/2f/8a/2dad6ea056f88f12602bdbdba19ed1d29a574bb8dbe034af0842eb2ee29f/tiktoken-0.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c27021a605b2778af07f84a33fe7c74b5c960a8cfac5d2a7a1075ed592cbe4" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/84/88/b0ec9383e7126f7cf033971dac81c4dea0954607db8c2fbfe109061bf730/tiktoken-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:45d654f049b4f7ed617ad0c66462c15cc41e5db120f37f122d5b57ffa2aec062" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/28/83/ed1900dd68890c891f55ded1f760f7878c5e16c8c68e576145105d66aa63/tiktoken-0.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34f73d93641b9cc73e19b18dbf9ce1baf086f1c4e18cfa36b952956843bca23c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/9a/a8/84ad6c23cfd51d2c39ba1bfbc70b6208c6be3e5cd15132a9d11cc93bfdd5/tiktoken-0.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fbfc5dda624c0f85c56bbf8f2ffb42964c798fc6fc1c321a452bf31d4ba21f5" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/7b/b5/7be4c78a10566ae068d88788a6fdf3a8b1162e7f78997999c46c919cdb69/tiktoken-0.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:853671af10636b581d632fe7b64b755301c73bc1f2ce837a8cdd9a44ab51f846" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/55/da/a0e90c85f36bd21ef4dbe881f9e259403c6fd6287841ff3691c1d2a5baab/tiktoken-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:56c4e7544be63c78265c82857b9f2a4e2190ae29541fe3467708fc7aabcb1522" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/1a/44/03c259d8df262181f0efab0159373435284f1074adf966418663879023e1/tiktoken-0.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:10e779827ddb0490a415d09d95f8e7a982fd8e14f88c4c2348358f722af3c415" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/e3/16/98ee535d30f7abf528ac25e78d67171cc2dfc1366d762cf79eb0dcc9054d/tiktoken-0.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:783892cdbec0d33f0f51373d8969e059ab1244af531a52338f702131a032a116" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/2f/bd/c3847b55e4fd6c6ab89ab75d258c725c67890734a4e58e28315ae2208ee1/tiktoken-0.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43f38d62b6a62a7c82be3770fcdc24cdf5bff3bdf718909d038b804ac774a025" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/8c/07/9a2c6e1d1ef138f79a6c943bf1c7c7e7cc159e2b7fbbe6ce5d176f963232/tiktoken-0.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72d0b30e08f1e856fa76ee423a3d3f0b1bc984cb6e86a21dbd7c5eee8f67f8f5" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ba/4f/ae9e36e43c0abbeb631b848697b22662cca5dbbe90a1b692b5c0ceda0fac/tiktoken-0.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa840eba09a0c1db0b436baf6cfe1ab7906f33fb663cf96f772a818bad5856a6" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/10/74/c6f69e46f98e42d6727853e4017d6287b57075905ff715fae0f35fa53173/tiktoken-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:642b8d9f266004629ea2457aa29a9eed4f1a031fd804f8c489edbf32df7026c3" },
 ]
 
 [[package]]
@@ -3165,28 +3168,28 @@ wheels = [
 
 [[package]]
 name = "uv"
-version = "0.8.4"
+version = "0.8.5"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/71/05/779581d8e5cd8d12dc3e2297280a03293f7b465bb5f53308479e508c5c44/uv-0.8.4.tar.gz", hash = "sha256:2ab21c32a28dbe434c9074f899ed8084955f7b09ac5e7ffac548d3454f77516f" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/83/94/e18a40fe6f6d724c1fbf2c9328806359e341710b2fd42dc928a1a8fc636b/uv-0.8.5.tar.gz", hash = "sha256:078cf2935062d5b61816505f9d6f30b0221943a1433b4a1de8f31a1dfe55736b" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/96/10/4d52b081defca3cfb4a11d6af3af4314fe7f289ba19e40d6cfab778f9257/uv-0.8.4-py3-none-linux_armv6l.whl", hash = "sha256:f9a5da616ca0d2bbe79367db9cf339cbaf1affee5d6b130a3be2779a917c14fa" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/36/fa/7847373d214de987e96ef6b820a4ed2fa5e1c392ecc73cd53e94013d6074/uv-0.8.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4d8422b3058998d87fee46d4d1a437e202407cafca8b8ac69e01c6479fbe0271" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/16/39/7d4b68132868c550ae97c3b2c348c55db47a987dff05ab0e5f577bf0e197/uv-0.8.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:edc813645348665a3b4716a7d5e961cf7c8d1d3bfb9d907a4f18cf87c712a430" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/e3/8f/f703e4ba41aae195d4958b701c2ee6cdbbbb8cdccb082845d6abfe834cf9/uv-0.8.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:c2323e915ae562db4ebcdf5e20d3dd37a14959d07cc54939d86ab0dcdbf08f58" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/59/f8/9366ceeb63f9dd6aa11375047762c1033d36521722e748b65a24e435f459/uv-0.8.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:96d7a68c360383d638c283811d57558fbf7b5f769ff4bdbc99ee2a3bf9a6e574" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/f2/e3/190eb0ca91b8a0e5f80f93aeb7924b12be89656066170d6e1244e90c5e80/uv-0.8.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:385dec5a0c0909d5a24af5b02db24b49b025cbed59c6225e4c794ff40069d9aa" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/ab/f6/b5fc5fe6e93e0294cbd8ba228d10b12e46a5e27b143565e868da758e0209/uv-0.8.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:b2230310ca303328c9fd351044fb81349f3ccfaa2863f135d37bfcee707adfd1" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/f5/f0/d01779df4ac2ae39bf440c97f53346f1b9eef17cc84a45ed66206e348650/uv-0.8.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86d64c66993eb0d9821caea27920175a27cd24df1eba8a340d8b3ae4074fac77" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/80/ca/48c78393cb3a73940e768b74f74c30ca7719de6f83457a125b9cfa0c37e0/uv-0.8.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:624cf5b7bdc5cc0253115fefaad40008205d4acf34b77b294479dfe4eacb9697" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/42/e2/5cf11c85fb48276b49979ea06e92c1e95524e1e4c5bccbd591a334c8de68/uv-0.8.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9cd287982f62419f98ca7182fbbc2fd0fad1a04008b956a88eb85ce1d522611" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/1c/b1/773dcd5ef4947a5bd7c183f1cc8afb9e761488ff1b48b46cb0d95bc5c8cf/uv-0.8.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:e6fa3754a2b965dceecfce8c38cacf7cd6b76a2787b9e189cf33acdb64a7472a" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/e6/8f/20dcb6aaa9c9d7e16320b5143b1fdaa5fd1ebc42a99e2d5f4283aafc59f1/uv-0.8.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9f2a7042553e85c66884a6a3c1b88e116bc5fe5e5d1c9b62f025b1de41534734" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/8a/19/9f9df99259d6725fc269d5394606919f32c3e0d21f486277c040cb7c5dad/uv-0.8.4-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:2c80470d7253bd26c5990f4914cfddc68a6bb4da7c7da316a29e99feafe272a1" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/00/f4/358576eea98eb4ba58135690a60f8052dbd8b50173a5c0e93e59c8797c2c/uv-0.8.4-py3-none-musllinux_1_1_i686.whl", hash = "sha256:b90eb86019ff92922dea54b8772074909ce7ab3359b2e8f8f3fe4d0658d3a898" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/51/0f/9e5ff7d73846d8c924a5ef262dee247b453b7b2bd2ba5db1a819c72bd176/uv-0.8.4-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:cad63a02a735ba591679d713376767fc7649ad1e7097a95d0d267a68c2e803fc" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/3c/fa/58c416c634253bdd7ec50baa5d79010f887453425a62e6a23f9668a75305/uv-0.8.4-py3-none-win32.whl", hash = "sha256:b83cd9eeb4c63ab69c6e8d0e26e57b5a9a8b1dca4015f4ddf088ed4a234e7018" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/76/8e/2d6f5bce0f41074122caed1672f90f7ed5df2bd9827c8723c73a657bea7b/uv-0.8.4-py3-none-win_amd64.whl", hash = "sha256:ad056c8f6568d9f495e402753e79a092f28d513e6b5146d1c8dc2bdea668adb1" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/58/de/196e862af4c3b2ff8cb4a7a3ad38ecf0306fa87d03ec9275f16e2f5dc416/uv-0.8.4-py3-none-win_arm64.whl", hash = "sha256:41f3a22550811bf7a0980b3d4dfce09e2c93aec7c42c92313ae3d3d0b97e1054" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d9/b9/78cde56283b6b9a8a84b0bf9334442ed75a843310229aaf7f1a71fe67818/uv-0.8.5-py3-none-linux_armv6l.whl", hash = "sha256:e236372a260e312aef5485a0e5819a0ec16c9197af06d162ad5a3e8bd62f9bba" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ed/83/5deda1a19362ce426da7f9cc4764a0dd57e665ecbaddd9900d4200bc10ab/uv-0.8.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:53a40628329e543a5c5414553f5898131d5c1c6f963708cb0afc2ecf3e8d8167" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/06/6e/80b08ee544728317d9c8003d4c10234007e12f384da1c3dfe579489833c9/uv-0.8.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:43a689027696bc9c62e6da3f06900c52eafc4debbf4fba9ecb906196730b34c8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/34/f6/47a44dabfc25b598ea6f2ab9aa32ebf1cbd87ed8af18ccde6c5d36f35476/uv-0.8.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:a34d783f5cef00f1918357c0cd9226666e22640794e9e3862820abf4ee791141" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ef/7d/ee7c2514e064412133ee9f01c4c42de20da24617b8c25d81cf7021b774d8/uv-0.8.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2140383bc25228281090cc34c00500d8e5822877c955f691d69bbf967e8efa73" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/f9/e7/5233cf5cbcca8ea65aa1f1e48bf210dc9773fb86b8104ffbc523be7f6a3f/uv-0.8.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6b449779ff463b059504dc30316a634f810149e02482ce36ea35daea8f6ce7af" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d8/54/6cabb2a0347c51c8366ca3bffeeebd7f829a15f6b29ad20f51fd5ca9c4bd/uv-0.8.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:a7f8739d05cc513eee2f1f8a7e6c482a9c1e8860d77cd078d1ea7c3fe36d7a65" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/3c/7a/b84d994d52f20bc56229840c31e77aff4653e5902ea7b7c2616e9381b5b8/uv-0.8.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:62ebbd22f780ba2585690332765caf9e29c9758e48a678148e8b1ea90580cdb9" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/c8/f1/7552f2bea528456d34bc245f2959ce910631e01571c4b7ea421ead9a9fc6/uv-0.8.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4f8dd0555f05d66ff46fdab551137cc2b1ea9c5363358913e2af175e367f4398" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/57/9b/46aadd186a1e16a23cd0701dda0e640197db49a3add074a47231fed45a4f/uv-0.8.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38c04408ad5eae7a178a1e3b0e09afeb436d0c97075530a3c82de453b78d0448" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/c0/31/6661adedaba9ebac8bb449ec9901f8cbf124fa25e0db3a9e6cf3053cee88/uv-0.8.5-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:73e772caf7310af4b21eaf8c25531b934391f1e84f3afa8e67822d7c432f6dad" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/11/f2/73fb5c3156fdae830b83edec2f430db84cb4bc4b78f61d21694bd59004cb/uv-0.8.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3ddd7d8c01073f23ba2a4929ab246adb30d4f8a55c5e007ad7c8341f7bf06978" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b5/29/774c6f174c53d68ae9a51c2fabf1b09003b93a53c24591a108be0dc338d7/uv-0.8.5-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:7d601f021cbc179320ea3a75cd1d91bd49af03d2a630c4d04ebd38ff6b87d419" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a9/b0/5d164ce84691f5018c5832e9e3371c0196631b1f1025474a179de1d6a70a/uv-0.8.5-py3-none-musllinux_1_1_i686.whl", hash = "sha256:6ee97b7299990026619c20e30e253972c6c0fb6fba4f5658144e62aa1c07785a" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d1/73/4d8baefb4f4b07df6a4db7bbd604cb361d4f5215b94d3f66553ea26edfd4/uv-0.8.5-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:09804055d6346febf0767767c04bdd2fab7d911535639f9c18de2ea744b2954c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/44/2a/3d074391df2c16c79fc6bf333e4bde75662e64dac465050a03391c75b289/uv-0.8.5-py3-none-win32.whl", hash = "sha256:6362a2e1fa535af0e4c0a01f83e666a4d5f9024d808f9e64e3b6ef07c97aff54" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/3c/2f/e850d3e745ccd1125b7a48898421824700fd3e996d27d835139160650124/uv-0.8.5-py3-none-win_amd64.whl", hash = "sha256:dd89836735860461c3a5563731e77c011d1831f14ada540f94bf1a7011dbea14" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/6f/df/e5565b3faf2c6147a877ab7e96ef31e2333f08c5138a98ce77003b1bf65e/uv-0.8.5-py3-none-win_arm64.whl", hash = "sha256:37c1a22915392014d8b4ade9e69e157c8e5ccdf32f37070a84f749a708268335" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📝 Summary
This pull request updates dependencies and versions across the `fabricatio-tool` and `fabricatio-core` packages, introduces new features for tool handling and JSON schema processing, and includes several refactors and fixes to improve stability and functionality.

## 🧾 Changes Proposed
- Updated `fabricatio` and `grpcio` versions.
- Bumped `fabricatio-tool` version to `0.5.2-dev3` with multiple pre-releases.
- Implemented MCP client to toolbox conversion in the `toolbox` module.
- Improved tool function generation and execution logic.
- Added tool retrieval and existence checking functionality.
- Integrated Python function template generation for tools.
- Added `signify` crate for JSON schema processing.
- Updated `rmcp` to version `0.4.0` and removed `oauth2`.
- Fixed ANSI reset code appending in core log messages.

## 📋 Motivation
These changes are necessary to keep the project up-to-date with the latest dependencies, enhance tool interoperability (especially with MCP), and improve overall robustness and developer experience. The addition of schema processing and tool templating helps streamline tool development and integration.

## 🧪 Testing
- Changes were tested locally during development.
- Integration tests were run to ensure compatibility with updated dependencies.
- Manual verification of tool generation and MCP conversion functionality was performed.
- No new benchmarks included, but performance remains consistent with prior versions.

## 📦 Dependencies
- This PR depends on the release of `rmcp v0.4.0`.
- There are no breaking changes intended, but consumers should verify compatibility with the updated dependencies.

## 🧭 Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] I have added relevant documentation if needed.
- [x] I have updated tests where appropriate.
- [x] This change is not a trivial refactoring, typo fix, or comment update.
